### PR TITLE
Fix user-for-update when no password is provided

### DIFF
--- a/src/keycloak/user.clj
+++ b/src/keycloak/user.clj
@@ -18,18 +18,22 @@
 (defn user-for-update
   ^org.keycloak.representations.idm.UserRepresentation
   [{:keys [username first-name last-name email enabled attributes password] :or {enabled true} :as person}]
-  (set-attributes ^org.keycloak.representations.idm.UserRepresentation
-                  (hint-typed-doto "org.keycloak.representations.idm.UserRepresentation" (UserRepresentation.)
-                    (.setUsername username)
-                    (.setFirstName first-name)
-                    (.setLastName last-name)
-                    (.setEmail email)
-                    (.setCredentials [(hint-typed-doto "org.keycloak.representations.idm.CredentialRepresentation" (CredentialRepresentation.)
-                                                       (.setType CredentialRepresentation/PASSWORD)
-                                                       (.setValue password))])
-                    (.setEnabled enabled)
+  (let [user-no-password (set-attributes ^org.keycloak.representations.idm.UserRepresentation
+                          (hint-typed-doto "org.keycloak.representations.idm.UserRepresentation" (UserRepresentation.)
+                                           (.setUsername username)
+                                           (.setFirstName first-name)
+                                           (.setLastName last-name)
+                                           (.setEmail email)
+                                           (.setEnabled enabled)
                     ;;setRealmRoles has a bug with the admin REST API and doesn't work
-                    ) attributes))
+                                           )
+                                         attributes)]
+    (if password
+      (doto user-no-password
+        (.setCredentials [(hint-typed-doto "org.keycloak.representations.idm.CredentialRepresentation" (CredentialRepresentation.)
+                                           (.setType CredentialRepresentation/PASSWORD)
+                                           (.setValue password))]))
+      user-no-password)))
 
 (defn user-for-enablement ^org.keycloak.representations.idm.UserRepresentation
   [enabled?]


### PR DESCRIPTION
It is my understanding that the function `user-for-update` should allow to update any field of an UserRepresentation without any of them being mandatory.
However this isn't the case for the password which throws a NullPointerException if it isn't provided which forces a password change for every user modification and doesn't seem right. This PR aims at fixing this issue by setting the credentials only if there is a password given. 