### PR TITLE
Upgrade SCI

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -37,7 +37,7 @@
         ;;diff library used by the reconciliation loop
         juji/editscript     {:mvn/version "0.5.7"}
 
-        borkdude/sci        {:mvn/version "0.1.1-alpha.9"}
+        org.babashka/sci    {:mvn/version "0.3.2"}
         camel-snake-kebab/camel-snake-kebab   {:mvn/version "0.4.2"}
 
         ;;used by starter to extract reliably the env var


### PR DESCRIPTION
SCI has moved to a new organization: `org.babashka/sci {:mvn/version "0.3.2"}`.

Having both `borkdude/sci` and `org.babashka/sci` on the classpath can cause problems.