### PR TITLE
Bumps Resteasy and Cloud Secret Manager to address CVEs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
         amperity/vault-clj {:mvn/version "1.0.0"}
         ;; used for the google secret manager Vault
         ;com.google.cloud/libraries-bom              {:mvn/version "24.0.0"}
-        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.0.4"}
+        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.0.7"}
 
         ;; keycloak stuff
         org.keycloak/keycloak-adapter-core   {:mvn/version "18.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -67,12 +67,12 @@
         com.fasterxml.jackson.core/jackson-core                 {:mvn/version "2.13.2"}
         com.fasterxml.jackson.core/jackson-databind             {:mvn/version "2.13.2"}
         com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider {:mvn/version "2.13.2"}
-        org.jboss.resteasy/resteasy-jackson2-provider       {:mvn/version "3.13.2.Final"}
-        org.jboss.resteasy/resteasy-client                  {:mvn/version "3.13.2.Final"}
-        org.jboss.resteasy/resteasy-multipart-provider      {:mvn/version "3.13.2.Final"}
-        org.jboss.resteasy/resteasy-jaxrs                   {:mvn/version "3.13.2.Final"}
-        org.jboss.resteasy/resteasy-jettison-provider       {:mvn/version "3.13.2.Final"}
-        org.jboss.resteasy/resteasy-jaxb-provider           {:mvn/version "3.13.2.Final"}
+        org.jboss.resteasy/resteasy-jackson2-provider       {:mvn/version "3.15.3.Final"}
+        org.jboss.resteasy/resteasy-client                  {:mvn/version "3.15.3.Final"}
+        org.jboss.resteasy/resteasy-multipart-provider      {:mvn/version "3.15.3.Final"}
+        org.jboss.resteasy/resteasy-jaxrs                   {:mvn/version "3.15.3.Final"}
+        org.jboss.resteasy/resteasy-jettison-provider       {:mvn/version "3.15.3.Final"}
+        org.jboss.resteasy/resteasy-jaxb-provider           {:mvn/version "3.15.3.Final"}
 
         org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec {:mvn/version "1.0.2.Final"}
 


### PR DESCRIPTION
Sorry! I was working through a list for SOC2 compliance; I didn't realize these were related.

This change resolves the following:
* [CVE-2020-25633](https://nvd.nist.gov/vuln/detail/CVE-2020-25633)
* [CVE-2020-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647)