### PR TITLE
Fixes CVE 2022-41854

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,7 @@
         ;; used when exporting secrets in json/yaml at init
 
         metosin/jsonista     {:mvn/version "0.3.6"}
-        clj-commons/clj-yaml {:mvn/version "0.7.109"}
+        clj-commons/clj-yaml {:mvn/version "1.0.26"}
 
         amperity/vault-clj {:mvn/version "1.0.0"}
         ;; used for the google secret manager Vault

--- a/test/keycloak/deployment_test.clj
+++ b/test/keycloak/deployment_test.clj
@@ -31,10 +31,32 @@
 
 (def admin-login "admin")
 (def admin-password "secretadmin")
-(def auth-server-url "http://localhost:8090/auth")
+(def auth-server-url "http://localhost:8090")
 
 (def integration-test-conf
   (deployment/client-conf auth-server-url "master" "admin-cli"))
+
+(def LOGIN {:bruteForceProtected true
+            :rememberMe true
+            :resetPasswordAllowed true})
+
+(def SMTP {:host "smtp.eu.mailgun.org"
+           :port 587
+           :from "admin@example.com"
+           :auth true
+           :starttls true
+           :replyTo "example"
+           :user "postmaster@mg.example.com"
+           :password "yo"
+           })
+
+(def THEMES {:internationalizationEnabled true
+             :supportedLocales #{"en" "fr"}
+             :defaultLocale "fr"
+             :loginTheme "mytheme"
+             :accountTheme "mytheme"
+             :adminTheme nil
+             :emailTheme "mytheme"} )
 
 (deftest ^:integration deployment-test
   (let [admin-client (deployment/keycloak-client integration-test-conf admin-login admin-password)]


### PR DESCRIPTION
The version of snakeyaml that comes with clj-yaml has been flagged with CVE 2022-41854. This PR will move us to a newer clj-yaml that includes a newer snakeyaml.

https://nvd.nist.gov/vuln/detail/CVE-2022-41854

I also fixed a test that was failing, but there are two others I'm unsure how to resolve. The vault test is looking for an environment variable I don't have set, the starter test is looking for an EDN file that doesn't appear to be a part of this project. Neither of these are YAML related! 🙂