### PR TITLE
Bumps google-cloud-secretmanager to address CVE-2022-3171

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
         amperity/vault-clj                          {:mvn/version "1.0.0"}
         ;; used for the google secret manager Vault
                                         ;com.google.cloud/libraries-bom              {:mvn/version "24.0.0"}
-        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.0.7"}
+        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.10.0"}
 
         ;; keycloak stuff
         org.keycloak/keycloak-common         {:mvn/version "20.0.3"}


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-3171

Sorry I missed this one with my last PR! 