### PR TITLE
Bumps clj-yaml and google-cloud-secretmanager

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,12 +46,12 @@
         ;; used when exporting secrets in json/yaml at init
 
         metosin/jsonista     {:mvn/version "0.3.6"}
-        clj-commons/clj-yaml {:mvn/version "1.0.26"}
+        clj-commons/clj-yaml {:mvn/version "1.0.27"}
 
         amperity/vault-clj                          {:mvn/version "1.0.0"}
         ;; used for the google secret manager Vault
                                         ;com.google.cloud/libraries-bom              {:mvn/version "24.0.0"}
-        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.22.0"}
+        com.google.cloud/google-cloud-secretmanager {:mvn/version "2.23.0"}
 
         ;; keycloak stuff
         org.keycloak/keycloak-common         {:mvn/version "20.0.3"}


### PR DESCRIPTION
Addreses these vulnerabilities:
- CVE-2023-2976
- CVE-2022-1471