### PR TITLE
Moves to newer versions of logging libraries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
              "confluent" {:url "https://packages.confluent.io/maven/"}}
 
  :deps {org.clojure/clojure       {:mvn/version "1.11.1"}
-        org.clojure/tools.logging {:mvn/version "1.1.0"}
+        org.clojure/tools.logging {:mvn/version "1.2.4"}
         org.clojure/java.data     {:mvn/version "1.0.86"}
 
         talltale/talltale {:mvn/version "0.5.14"}
@@ -76,11 +76,9 @@
         ;org.jboss.resteasy/resteasy-jettison-provider           {:mvn/version "3.15.3.Final"}
         ;org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec {:mvn/version "1.0.2.Final"}
 
-        org.slf4j/slf4j-api            {:mvn/version "2.0.0-alpha1"}
-        ch.qos.logback/logback-classic {:mvn/version "1.3.0-alpha5"}
-        ch.qos.logback/logback-core    {:mvn/version "1.3.0-alpha5"}
-
-        }
+        org.slf4j/slf4j-api            {:mvn/version "2.0.11"}
+        ch.qos.logback/logback-classic {:mvn/version "1.3.14"}
+        ch.qos.logback/logback-core    {:mvn/version "1.3.14"}}
 
  :aliases {:repl     {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
                       :main-opts  ["-m" "figwheel.main" "-b" "dev" "-r"]}


### PR DESCRIPTION
Logback 1.3.0-alpha5 is being flagged for CVE-2023-6378, this should resolve the issue.