### PR TITLE
Bumps clj-common/fs to address CVE-2024-26308

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
 
         talltale/talltale {:mvn/version "0.5.14"}
 
-        clj-commons/fs {:mvn/version "1.6.309"}
+        clj-commons/fs {:mvn/version "1.6.311"}
 
         cheshire/cheshire {:mvn/version "5.13.0"}
         clj-http/clj-http {:mvn/version "3.12.3"}

--- a/src/keycloak/vault/hashicorp.clj
+++ b/src/keycloak/vault/hashicorp.clj
@@ -1,7 +1,7 @@
 (ns keycloak.vault.hashicorp
-  (:require [vault.core :as vault]
+  (:require [vault.client :as vault]
             [vault.client.http]
-            [vault.secrets.kvv2 :as vault-kvv2]
+            [vault.secret.kv.v2 :as vault-kvv2]
             [keycloak.vault.protocol :as vault-protocol :refer [Vault]]))
 
 (defn vault-url
@@ -20,7 +20,7 @@
    (vault/new-client vault-url)))
 
 (defn authenticate!  [client token]
-  (vault/authenticate! client :token token))
+  (vault/authenticate! client token))
 
 (defn- write-secret! [client token mount path payload]
   (let [authenticated-client (authenticate! client token)]


### PR DESCRIPTION
Bumps clj-common/fs to address CVE-2024-26308
- https://www.cve.org/CVERecord?id=CVE-2024-26308

Fixes import of Vault libraries.