### PR TITLE
Moves to Keycloak 24.0.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -54,17 +54,17 @@
         com.google.cloud/google-cloud-secretmanager {:mvn/version "2.23.0"}
 
         ;; keycloak stuff
-        org.keycloak/keycloak-common         {:mvn/version "24.0.2"}
-        org.keycloak/keycloak-core           {:mvn/version "24.0.2"}
-        org.keycloak/keycloak-authz-client   {:mvn/version "24.0.2"}
-        org.keycloak/keycloak-policy-enforcer{:mvn/version "24.0.2"}
-        org.keycloak/keycloak-adapter-core   {:mvn/version "24.0.2"}
-        org.keycloak/keycloak-adapter-spi    {:mvn/version "24.0.2"}
+        org.keycloak/keycloak-common         {:mvn/version "24.0.5"}
+        org.keycloak/keycloak-core           {:mvn/version "24.0.5"}
+        org.keycloak/keycloak-authz-client   {:mvn/version "24.0.5"}
+        org.keycloak/keycloak-policy-enforcer{:mvn/version "24.0.5"}
+        org.keycloak/keycloak-adapter-core   {:mvn/version "24.0.5"}
+        org.keycloak/keycloak-adapter-spi    {:mvn/version "24.0.5"}
         org.jboss.logging/jboss-logging      {:mvn/version "3.5.3.Final"}
         org.apache.httpcomponents/httpclient {:mvn/version "4.5.14"}
 
         ;;all the deps below are for the admin client (don't know why the transitive deps didn't work)
-        org.keycloak/keycloak-admin-client                      {:mvn/version "24.0.2"}
+        org.keycloak/keycloak-admin-client                      {:mvn/version "24.0.5"}
         ;com.fasterxml.jackson.core/jackson-core                 {:mvn/version "2.17.0"}
         ;com.fasterxml.jackson.core/jackson-databind             {:mvn/version "2.17.0"}
         ;com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider {:mvn/version "2.17.0"}

--- a/docker/start-keycloak-docker.sh
+++ b/docker/start-keycloak-docker.sh
@@ -8,4 +8,4 @@ docker run -d \
        --name keycloak-dev \
        -p 127.0.0.1:9990:9990 \
        -p 127.0.0.1:8080:8080 \
-       quay.io/keycloak/keycloak:24.0.2 start-dev
+       quay.io/keycloak/keycloak:24.0.5 start-dev

--- a/src/keycloak/utils.clj
+++ b/src/keycloak/utils.clj
@@ -8,7 +8,7 @@
 (defn keycloak-running? [keycloak-client]
   (try
     (-> keycloak-client (.realm "master") (.toRepresentation) bean)
-   ; (catch javax.ws.rs.ProcessingException pe false)
+   ; (catch jakarta.ws.rs.ProcessingException pe false)
    ; (catch java.net.ConnectException ce false)
     ))
 

--- a/test/keycloak/backend_test.clj
+++ b/test/keycloak/backend_test.clj
@@ -47,9 +47,6 @@
                     headers
                     (kc-authn/auth-cookie token))}))
 
-(defn yada-test-context [token]
-  {:request (request-for :get "/protected" (headers-with-token-as-header {} token))})
-
 (def EXPIRED_TOKEN_BAD_REALM {:access_token
  "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxYnIwakNmanZXRXJfV0tkT1FSVzdkTkNiZmZHeXZQaVROTVA2ZjdYSVpZIn0.eyJleHAiOjE2MTM3NTk5MTAsImlhdCI6MTYxMzc1OTYxMCwianRpIjoiNTdmZjFmNjktNDk2ZC00MTA5LWI1ZTctZGFlYTk1NDY4Mzg0IiwiaXNzIjoiaHR0cDovL2xvZ2luLmRlZmF1bHQubWluaWt1YmUuZGV2bWFjaGluZS9hdXRoL3JlYWxtcy9lbGVjdHJlIiwiYXVkIjoiYWNjb3VudCIsInN1YiI6ImRkMTdlODkzLTFmYWYtNDBjMi04MzA0LTFiZjI1NjMxOTkxOCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImRpZmZ1c2lvbi1mcm9udGVuZCIsInNlc3Npb25fc3RhdGUiOiI3MzgzMGM1Mi03YWE2LTRmMWYtOTFmZS0xMWQ1NzllMDZkZmEiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib3JnLWFkbWluIiwiYXBpLXJlY2hlcmNoZS1saWJyZSIsIm1hbmFnZXIiLCJncm91cC1hZG1pbiIsImVsZWN0cmUtYWRtaW4iLCJvZmZsaW5lX2FjY2VzcyIsImFwaS1hbGltZW50YXRpb24tdW5pdGFpcmUiLCJhcGktYWxpbWVudGF0aW9uIiwiYXBpLWFsaW1lbnRhdGlvbi1pbml0IiwidW1hX2F1dGhvcml6YXRpb24iLCJlbXBsb3llZSIsImFwaS1yZWNoZXJjaGUtY2libGVlIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJvcmctcmVmIjoiZWxlY3RyZU5HIiwibmFtZSI6IkrDqXLDqW1pZSBHUk9EWklTS0kiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJqZ3JvZHppc2tpIiwiZ2l2ZW5fbmFtZSI6IkrDqXLDqW1pZSIsImZhbWlseV9uYW1lIjoiR1JPRFpJU0tJIiwiZW1haWwiOiJqZ3JvZHppc2tpQGVsZWN0cmUuY29tIiwiZ3JvdXAiOlsiL2VsZWN0cmVORy9pdCJdfQ.by7EFdx2TSVg7Zmd2EtAUD0eUKIgQvCoDvETNqN-qrbWCLVEc1wpCOhXp1DPa8W14p6xTIhgkCxt000hSeKE9YobG8W9GdxBZTWHtbG8L6YtCePW4pW9MF-YxAcsclOhAXlCukTXAlozz6RXV6byZqgL9HVvfVSxQskdoJd2zXGQZWCgpvSnWcpMkVrrXIXD-9EfkpwMCr9OHYKe50YRax5RjH72fY7m2WIpZyeaS6ZNi_Ud5nxTRFJHBhhRARLltjaUpB_Guv-6TGYDI46jNCozgJMlYiJkaTOy1o3s10jVowqXNxxaCNQP1zOX7Swri6UCkleuhiG4AOxA1XjRcg",
  :expires_in 300,
@@ -77,6 +74,9 @@
      (cond-> options
              (:body options) (update :body b/to-byte-buffers)
              true (update :headers #(merge {"host" "localhost"} %))))))
+
+(defn yada-test-context [token]
+  {:request (request-for :get "/protected" (headers-with-token-as-header {} token))})
 
 (defn yada-test-context-missing-token []
   {:request (request-for :get "/protected" {:headers {"content-type" "application/transit+json"

--- a/test/keycloak/deployment_test.clj
+++ b/test/keycloak/deployment_test.clj
@@ -92,7 +92,7 @@
                     (is (= username (:username extracted-token)))))))))
         (testing "realm deletion"
           (delete-realm! admin-client realm-name)
-          (is (thrown? javax.ws.rs.NotFoundException (get-realm admin-client realm-name))))))))
+          (is (thrown? jakarta.ws.rs.NotFoundException (get-realm admin-client realm-name))))))))
 
 (defn delete-realms-except [realms-to-keep]
   (let [admin-client (deployment/keycloak-client integration-test-conf admin-login admin-password)

--- a/test/keycloak/reconciliation_test.clj
+++ b/test/keycloak/reconciliation_test.clj
@@ -105,7 +105,7 @@
             (is (= "to-be-modified-1" (:username (first (:user/updates plan)))))))
         (testing "realm deletion"
           (admin/delete-realm! admin-client realm-name)
-          (is (thrown? javax.ws.rs.NotFoundException (admin/get-realm admin-client realm-name)))))))
+          (is (thrown? jakarta.ws.rs.NotFoundException (admin/get-realm admin-client realm-name)))))))
   (testing "Fetch the existing users and diff the one that need update or creation"
     (let [])))
 
@@ -189,7 +189,7 @@
                            (-> (get plan :user/updates) first :groups) => [{:path "/group2"}])))))))
         (testing "realm deletion"
           (admin/delete-realm! admin-client realm-name)
-          (is (thrown? javax.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
+          (is (thrown? jakarta.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
 
 (defn- get-roles->users [admin-client realm-name roles]
   (into {} (map (fn [[role users]] [role (into [] (map bean/UserRepresentation->map users))]) (user/get-users-aggregated-by-realm-roles admin-client realm-name roles))))
@@ -246,7 +246,7 @@
                    (get empty-plan :realm-role-mappings/deletions) => empty?)))))
         (testing " finally realm is deleted"
           (admin/delete-realm! admin-client realm-name)
-          (is (thrown? javax.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
+          (is (thrown? jakarta.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
 
 (deftest ^:integration groups-test
   (let [admin-client (deployment/keycloak-client integration-test-conf admin-login admin-password)]
@@ -313,7 +313,7 @@
                    (get empty-plan :groups/deletions) => empty?)))))
         (testing " finally realm is deleted"
           (admin/delete-realm! admin-client realm-name)
-          (is (thrown? javax.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
+          (is (thrown? jakarta.ws.rs.NotFoundException (admin/get-realm admin-client realm-name))))))))
 
 
 (comment

--- a/test/keycloak/starter_test.clj
+++ b/test/keycloak/starter_test.clj
@@ -112,7 +112,7 @@
                 (fact secret-value => (comp not str/blank?)))))))
       (testing "realm deletion"
         (delete-realm! admin-client realm-name)
-        (is (thrown? javax.ws.rs.NotFoundException (get-realm admin-client realm-name)))
+        (is (thrown? jakarta.ws.rs.NotFoundException (get-realm admin-client realm-name)))
         ))))
 
 (deftest ^:integration starter-reconciliation-test
@@ -137,7 +137,7 @@
         (starter/init! admin-client (assoc-in config [:realm :name] realm-name) infra-context {:dry-run? true :apply-deletions? true}))
       (testing "realm deletion"
         (delete-realm! admin-client realm-name)
-        (is (thrown? javax.ws.rs.NotFoundException (get-realm admin-client realm-name)))))))
+        (is (thrown? jakarta.ws.rs.NotFoundException (get-realm admin-client realm-name)))))))
 
 (deftest config-test
   (let [environment  (sci/new-var 'environment  "staging")


### PR DESCRIPTION
This is the latest version of the 24.x client libraries. It appears that this version also includes library changes that require us to import from the `jakarta` namespace rather than the `javax` namespace.

    javax.ws.rs.NotFoundException -> jakarta.ws.rs.NotFoundException